### PR TITLE
Segments' translation

### DIFF
--- a/assets/js/segments/view.js
+++ b/assets/js/segments/view.js
@@ -273,6 +273,7 @@ function _createSegment (type, variantString, width, isUnmovable, palette, randS
 
     var innerEl = document.createElement('span')
     innerEl.classList.add('name')
+    innerEl.setAttribute('data-i18n', 'segment-info:segments.' + type + '.name')
     innerEl.innerHTML = name
     el.appendChild(innerEl)
 


### PR DESCRIPTION
Addition of data-i18n to <span> that contains segment's name.

There are few issues, that I spot and will try to resolve in this PR:

- it look like segments are added to DOM after initial execution of translation, we need to deffer translation or even execute it every time new segment is added to the "mix"

- for now translations are added only to segments name below segment - there are still untraslated strings in options above segment

- there is some inconsistency between source translations and raw, hardcoded strings (content of tags in DOM)