### PR TITLE
Put back movable sky styles (but do not turn on)

### DIFF
--- a/assets/css/_sky.scss
+++ b/assets/css/_sky.scss
@@ -1,0 +1,72 @@
+#street-section-sky {
+  position: absolute;
+  left: 0;
+  right: -2000px; // TODO hack - this makes the sky wide enough for 400' streets - sky scrolls with the street
+  height: $canvas-baseline + 150px;
+  background-size: 100% 350px;
+  background-repeat: no-repeat;
+  background-position: 0 0;
+  background-color: $sky-colour;
+  pointer-events: none;
+}
+
+.rear-clouds,
+.front-clouds {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  background-repeat: repeat-x;
+  background-position: 0 0;
+}
+
+.rear-clouds {
+  height: 120px;
+  bottom: 735px;
+  background-image: url('/images/sky-rear.png');
+  background-size: 250px 120px;
+}
+
+.front-clouds {
+  height: 280px;
+  bottom: 735px - 330px;
+  border-bottom: 50px solid rgb(165, 196, 209);
+  background-image: url('/images/sky-front.png');
+  background-size: 250px 280px;
+  opacity: 0.5;
+}
+
+// A setting activates this class and turns on environmental animations
+// This is so it can be disabled based on preference or performance reasons
+body.environment-animations {
+  .rear-clouds {
+    animation-name: rear-clouds-move;
+    animation-duration: 60s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  .front-clouds {
+    animation-name: front-clouds-move;
+    animation-duration: 30s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+}
+
+@keyframes rear-clouds-move {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 250px 0;
+  }
+}
+
+@keyframes front-clouds-move {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 250px 0;
+  }
+}

--- a/assets/css/_street-section.scss
+++ b/assets/css/_street-section.scss
@@ -84,54 +84,6 @@
   height: $canvas-height + 40;
 }
 
-.rear-clouds,
-.front-clouds {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  background-repeat: repeat-x;
-  background-position: 0 0;
-  z-index: -1;
-
-  &.rear-clouds {
-    height: 120px;
-    bottom: 330px;
-    background-image: url('/images/sky-rear.png');
-    background-size: 250px 120px;
-  }
-
-  &.front-clouds {
-    height: 280px;
-    bottom: 330px - 330px;
-    border-bottom: 50px solid rgb(165, 196, 209);
-    background-image: url('/images/sky-front.png');
-    background-size: 250px 280px;
-    opacity: 0.5;
-  }
-}
-
-#street-section-sky {
-  position: absolute;
-  left: 0;
-  right: -2000px; // TODO hack
-  height: $canvas-baseline + 150px;
-  background-size: 100% 350px;
-  background-repeat: no-repeat;
-  background-position: 0 0;
-  background-color: $sky-colour;
-  pointer-events: none;
-
-  .rear-clouds {
-    bottom: 735px;
-    z-index: auto;
-  }
-
-  .front-clouds {
-    bottom: 735px - 330px;
-    z-index: auto;
-  }
-}
-
 #street-section-dirt {
   position: absolute;
   left: 0;

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -10,6 +10,7 @@
 @import 'dialogs';
 @import 'buttons';
 @import 'gallery';
+@import 'sky';
 @import 'street-section';
 @import 'street-name';
 @import 'street-metadata';


### PR DESCRIPTION
They were turned off initially because of the load it placed on browsers and it seems to not have gone away.

Curious how much of it has to do with the need to expand the element to some ludicrous width so as to deal with extremely long streets. Would making it a smaller element to animate help?