### PR TITLE
Fix regression in deleting segments

### DIFF
--- a/assets/scripts/segments/remove.js
+++ b/assets/scripts/segments/remove.js
@@ -1,11 +1,11 @@
-/* global street, _switchSegmentElAway, _createDomFromData */
+/* global street, _createDomFromData */
 
 import { msg } from '../app/messages'
 import { registerKeypress } from '../app/keypress'
 import { showStatusMessage } from '../app/status_message'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { getHoveredSegmentEl } from './hover'
-import { segmentsChanged } from './view'
+import { segmentsChanged, switchSegmentElAway } from './view'
 
 /**
  * Removes a segment, given the element to remove
@@ -24,7 +24,7 @@ export function removeSegment (el) {
   infoBubble.hideSegment()
 
   // Animates segment away
-  _switchSegmentElAway(el)
+  switchSegmentElAway(el)
 
   segmentsChanged()
   showStatusMessage(msg('STATUS_SEGMENT_DELETED'), true)

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -4,7 +4,8 @@
 
 import { msg } from '../app/messages'
 import { infoBubble, INFO_BUBBLE_TYPE_SEGMENT } from '../info_bubble/info_bubble'
-import { removeElFromDOM, getElAbsolutePos } from '../util/dom_helpers'
+import { removeElFromDOM } from '../util/dom_helpers'
+import { getElAbsolutePos } from '../util/helpers'
 import { prettifyWidth } from '../util/width_units'
 import { draggingMove } from './drag_and_drop'
 import { SEGMENT_INFO } from './info'


### PR DESCRIPTION
@magul This is a patch for the `browserify-segments` PR (https://github.com/codeforamerica/streetmix/pull/556). We'd noticed that the remove button (or pressing backspace while hovering over a segment) had broken, but this should fix the problem.

Although I didn't want to do it in this patch, it may make sense to move `getElAbsolutePos()` from `/utils/helpers` to `/utils/dom_helpers` permanently.