### PR TITLE
Init cleanup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,9 +48,9 @@ module.exports = function (grunt) {
     // Sauce-based tests cannot be performed on pull request open by user that
     // doesn't have write permission to main repository
     // https://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests
-    (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) ?
-    ['env:test', 'express:app', 'protractor:saucelabs'] :
-    ['env:test', 'express:app']
+    (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)
+      ? ['env:test', 'express:app', 'protractor:saucelabs']
+      : ['env:test', 'express:app']
   ))
   grunt.registerTask('test:local:setup', ['shell'])
   grunt.registerTask('test:local', ['env:test', 'express:app', 'protractor:local'])

--- a/app.js
+++ b/app.js
@@ -17,7 +17,6 @@ var controllers = require('./app/controllers')
 var resources = require('./app/resources')
 var requestHandlers = require('./lib/request_handlers')
 var middleware = require('./lib/middleware')
-var logger = require('./lib/logger')()
 var exec = require('child_process').exec
 
 var app = module.exports = express()
@@ -34,7 +33,7 @@ app.use(requestHandlers.request_log)
 app.use(requestHandlers.request_id_echo)
 
 app.set('view engine', 'jade')
-app.set('views', __dirname + '/app/views')
+app.set('views', path.join(__dirname, '/app/views'))
 
 // Redirect to environment-appropriate domain, if necessary
 app.all('*', function (req, res, next) {
@@ -75,7 +74,7 @@ app.get('/.well-known/status', resources.well_known_status.get)
 app.use('/assets/css/styles.css', middleware.styles)
 
 // Build JavaScript bundle via browserify
-app.get('/assets/scripts/main.js', browserify(__dirname + '/assets/scripts/main.js', {
+app.get('/assets/scripts/main.js', browserify(path.join(__dirname, '/assets/scripts/main.js'), {
   cache: true,
   precompile: true,
   transform: [[{ presets: ['es2015'] }, babelify], envify({
@@ -85,7 +84,7 @@ app.get('/assets/scripts/main.js', browserify(__dirname + '/assets/scripts/main.
     TWITTER_CALLBACK_URI: config.get('twitter').oauth_callback_uri,
     ENV: config.get('env'),
     NO_INTERNET_MODE: config.get('no_internet_mode')
-  })],
+  })]
 }))
 
 // SVG bundled images served directly from packages

--- a/app/resources/v1/feedback.js
+++ b/app/resources/v1/feedback.js
@@ -1,5 +1,6 @@
 var config = require('config')
-var sendgrid = require('sendgrid')(config.email.sendgrid.username, config.email.sendgrid.password)
+var sendgrid = require('sendgrid')(
+  config.email.sendgrid.username, config.email.sendgrid.password)
 var isEmail = require('validator/lib/isEmail')
 var logger = require('../../../lib/logger.js')()
 
@@ -66,5 +67,4 @@ exports.post = function (req, res) {
     logger.info('Sendgrid: Feedback accepted. ', json)
     res.status(202).json({ msg: 'Feedback accepted.' })
   })
-
 } // END function - exports.post

--- a/app/resources/v1/streets.js
+++ b/app/resources/v1/streets.js
@@ -14,7 +14,7 @@ exports.post = function (req, res) {
 
   street.id = uuid.v1()
 
-  var request_ip = function (req) {
+  var requestIp = function (req) {
     if (req.headers['x-forwarded-for'] !== undefined) {
       return req.headers['x-forwarded-for'].split(', ')[0]
     } else {
@@ -34,7 +34,7 @@ exports.post = function (req, res) {
 
     street.name = body.name
     street.data = body.data
-    street.creator_ip = request_ip(req)
+    street.creator_ip = requestIp(req)
   }
 
   var handleCreateStreet = function (err, s) {
@@ -55,7 +55,6 @@ exports.post = function (req, res) {
       res.header('Location', config.restapi.baseuri + '/v1/streets/' + s.id)
       res.status(201).send(streetJson)
     })
-
   } // END function - handleCreateStreet
 
   var handleNewStreetNamespacedId = function (err, namespacedId) {
@@ -67,7 +66,6 @@ exports.post = function (req, res) {
 
     street.namespaced_id = namespacedId
     street.save(handleCreateStreet)
-
   } // END function - handleNewStreetNamespacedId
 
   var makeNamespacedId = function () {
@@ -86,7 +84,6 @@ exports.post = function (req, res) {
           handleNewStreetNamespacedId(err, (row ? row.seq : null))
         })
     }
-
   } // END function - makeNamespacedId
 
   var handleFindStreet = function (err, origStreet) {
@@ -102,7 +99,6 @@ exports.post = function (req, res) {
 
     street.original_street_id = origStreet
     makeNamespacedId()
-
   } // END function - handleFindStreet
 
   var saveStreet = function () {
@@ -111,7 +107,6 @@ exports.post = function (req, res) {
     } else {
       makeNamespacedId()
     }
-
   } // END function - saveStreet
 
   var handleFindUser = function (err, user) {
@@ -122,7 +117,6 @@ exports.post = function (req, res) {
 
     street.creator_id = user
     saveStreet()
-
   } // END function - handleFindUser
 
   if (req.loginToken) {
@@ -130,7 +124,6 @@ exports.post = function (req, res) {
   } else {
     saveStreet()
   }
-
 } // END function - exports.post
 
 exports.delete = function (req, res) {
@@ -142,7 +135,6 @@ exports.delete = function (req, res) {
     }
 
     res.status(204).end()
-
   } // END function - handleDeleteStreet
 
   var handleFindStreet = function (err, street) {
@@ -181,11 +173,9 @@ exports.delete = function (req, res) {
 
       street.status = 'DELETED'
       street.save(handleDeleteStreet)
-
     } // END function - handleFindUser
 
     User.findOne({ login_tokens: { $in: [ req.loginToken ] } }, handleFindUser)
-
   } // END function - handleFindStreet
 
   if (!req.loginToken) {
@@ -199,7 +189,6 @@ exports.delete = function (req, res) {
   }
 
   Street.findOne({ id: req.params.street_id }, handleFindStreet)
-
 } // END function - exports.delete
 
 exports.get = function (req, res) {
@@ -237,7 +226,6 @@ exports.get = function (req, res) {
       res.set('Location', config.restapi.baseuri + '/v1/streets/' + street.id)
       res.status(200).send(streetJson)
     })
-
   } // END function - handleFindStreet
 
   if (!req.params.street_id) {
@@ -246,7 +234,6 @@ exports.get = function (req, res) {
   }
 
   Street.findOne({ id: req.params.street_id }, handleFindStreet)
-
 } // END function - exports.get
 
 exports.find = function (req, res) {
@@ -284,7 +271,6 @@ exports.find = function (req, res) {
     }
 
     Street.findOne({ namespaced_id: namespacedId, creator_id: user._id }, handleFindStreet)
-
   } // END function - handleFindUser
 
   var handleFindStreets = function (err, results) {
@@ -339,9 +325,7 @@ exports.find = function (req, res) {
 
         json.streets = results
         res.status(200).send(json)
-
       }) // END - async.map
-
   } // END function - handleFindStreets
 
   if (creatorId) {
@@ -360,7 +344,6 @@ exports.find = function (req, res) {
       }
     ], handleFindStreets)
   }
-
 } // END function - exports.find
 
 exports.put = function (req, res) {
@@ -386,7 +369,6 @@ exports.put = function (req, res) {
     }
 
     res.status(204).end()
-
   } // END function - handleUpdateStreet
 
   var handleFindStreet = function (err, street) {
@@ -414,7 +396,6 @@ exports.put = function (req, res) {
 
       street.original_street_id = origStreet
       street.save(handleUpdateStreet)
-
     } // END function - handleFindOriginalStreet
 
     var updateStreetData = function () {
@@ -426,7 +407,6 @@ exports.put = function (req, res) {
       } else {
         street.save(handleUpdateStreet)
       }
-
     } // END function - updateStreetData
 
     var handleFindUser = function (err, user) {
@@ -452,7 +432,6 @@ exports.put = function (req, res) {
       }
 
       updateStreetData()
-
     } // END function - handleFindUser
 
     if (!street.creator_id) {
@@ -464,9 +443,7 @@ exports.put = function (req, res) {
       }
 
       User.findOne({ login_tokens: { $in: [ req.loginToken ] } }, handleFindUser)
-
     } // END else - street has a creator
-
   } // END function - handleFindStreet
 
   if (!req.params.street_id) {
@@ -475,5 +452,4 @@ exports.put = function (req, res) {
   }
 
   Street.findOne({ id: req.params.street_id }, handleFindStreet)
-
 } // END function - exports.put

--- a/app/resources/v1/translate.js
+++ b/app/resources/v1/translate.js
@@ -2,8 +2,6 @@
 
 var config = require('config')
 var fs = require('fs')
-var btoa = require('btoa')
-var request = require('superagent')
 var logger = require('../../../lib/logger.js')()
 
 exports.get = function (req, res) {
@@ -27,7 +25,7 @@ exports.get = function (req, res) {
 
   var handleGetFromTransifex = require('../../../lib/transifex.js')
 
-  var sendSuccessResponse = function(locale, resource, translation) {
+  var sendSuccessResponse = function (locale, resource, translation) {
     res.set({
       'Content-Type': 'application/json; charset=utf-8',
       'Location': config.restapi.baseuri + '/v1/translate/' + locale + '/' + resource,

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -21,7 +21,6 @@ exports.post = function (req, res) {
       logger.info({ user: userJson }, 'New user created.')
       res.header('Location', config.restapi.baseuri + '/v1/users/' + user.id)
       res.status(201).send(userJson)
-
     } // END function - handleCreateUser
 
     var handleUpdateUser = function (err, user) {
@@ -36,7 +35,6 @@ exports.post = function (req, res) {
 
       res.header('Location', config.restapi.baseuri + '/v1/users/' + user.id)
       res.status(200).send(userJson)
-
     } // END function - handleUpdateUser
 
     var handleFindUser = function (err, user) {
@@ -58,7 +56,6 @@ exports.post = function (req, res) {
           login_tokens: [ loginToken ]
         })
         u.save(handleCreateUser)
-
       } else {
         user.id = twitterCredentials.screenName
         user.twitter_credentials = {
@@ -68,12 +65,10 @@ exports.post = function (req, res) {
         user.login_tokens.push(loginToken)
         user.save(handleUpdateUser)
       }
-
     } // END function - handleFindUser
 
     // Try to find user with twitter ID
     User.findOne({ twitter_id: twitterCredentials.userId }, handleFindUser)
-
   } // END function - handleTwitterSignIn
 
   var body
@@ -91,7 +86,6 @@ exports.post = function (req, res) {
   } else {
     res.status(400).send('Unknown sign-in method used.')
   }
-
 } // END function - exports.post
 
 exports.get = function (req, res) {
@@ -174,7 +168,6 @@ exports.get = function (req, res) {
     } else {
       sendUserJson()
     }
-
   } // END function - handleFindUserById
 
   // Flag error if user ID is not provided
@@ -215,7 +208,6 @@ exports.delete = function (req, res) {
       return
     }
     res.status(204).end()
-
   } // END function - handleSaveUser
 
   var handleFindUser = function (err, user) {
@@ -238,7 +230,6 @@ exports.delete = function (req, res) {
 
     user.login_tokens.splice(idx, 1)
     user.save(handleSaveUser)
-
   } // END function - handleFindUser
 
   // Flag error if user ID is not provided
@@ -249,7 +240,6 @@ exports.delete = function (req, res) {
 
   var userId = req.params.user_id
   User.findOne({ id: userId }, handleFindUser)
-
 } // END function - exports.delete
 
 exports.put = function (req, res) {
@@ -268,7 +258,6 @@ exports.put = function (req, res) {
       return
     }
     res.status(204).end()
-
   } // END function - handleSaveUser
 
   var handleFindUser = function (err, user) {
@@ -290,7 +279,6 @@ exports.put = function (req, res) {
 
     user.data = body.data || user.data
     user.save(handleSaveUser)
-
   } // END function - handleFindUser
 
   // Flag error if user ID is not provided
@@ -301,5 +289,4 @@ exports.put = function (req, res) {
 
   var userId = req.params.user_id
   User.findOne({ id: userId }, handleFindUser)
-
 } // END function - exports.put

--- a/app/resources/v1/users_streets.js
+++ b/app/resources/v1/users_streets.js
@@ -39,15 +39,12 @@ exports.get = function (req, res) {
 
           json.streets = results
           res.status(200).send(json)
-
         }) // END - async.map
-
     } // END function - handleFindStreets
 
     Street.find({ creator_id: user._id, status: 'ACTIVE' })
       .sort({ updated_at: 'descending' })
       .exec(handleFindStreets)
-
   } // END function - handleFindUser
 
   // Flag error if user ID is not provided
@@ -57,5 +54,4 @@ exports.get = function (req, res) {
   }
 
   User.findOne({ id: req.params.user_id }, handleFindUser)
-
 } // END function - exports.get

--- a/app/views/_layout.jade
+++ b/app/views/_layout.jade
@@ -39,7 +39,3 @@ html(lang='en')
 
     script(src='https://platform.twitter.com/widgets.js')
     script(src='/assets/scripts/main.js')
-    script.
-      Stmx.preInit()
-    script.
-      Stmx.init()

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -16,8 +16,6 @@ import './vendor/polyfills/customevent' // customEvent in IE
 
 // Main object
 import { Stmx } from './app/initialization'
-window.Stmx = Stmx
-
 import { startListening } from './app/keypress'
 import { system } from './preinit/system_capabilities'
 // import modules for side-effects
@@ -74,3 +72,6 @@ window.addEventListener('stmx:everything_loaded', function (e) {
 
 // Start listening for keypresses
 startListening()
+
+Stmx.preInit()
+Stmx.init()

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "posttest": "mongo admin --eval 'db.shutdownServer()'",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-css": "sass-lint --config .sass-lint.yml  --verbose",
-    "lint-js": "standard ./**/*.js --verbose | snazzy",
+    "lint-js": "standard --verbose | snazzy",
     "translationsDownload": "node bin/download_translations.js"
   },
   "dependencies": {


### PR DESCRIPTION
I was trying to make it more browserifyable with main object `Stmx` - I was trying to use `standalone` option here, but it occurs, that after https://phabricator.babeljs.io/T2212 we would have to use `default` explicitly, so I was thinking about old CommonJS way of using `module.exports = Stmx` but after further thinking I end up with moving `Stmx.preInit()` and `Stmx.init()` into browserify bundle instead of leaving them in Jade template.

Second thing here is that we have some issue with `npm run lint-js` - it occurs, that we don't know how to create glob for that thing and with `./**/*.js` it doesn't lint a thing. I have remove this glob and found few other issues with code style and have fixed them.