### PR TITLE
Redirect /help/about to OpenCollective

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ app.all('*', function (req, res, next) {
   }
 })
 
-app.get('/help/about', function (req, res, next) {
+app.get('/help/about', function (req, res) {
   res.redirect('https://www.opencollective.com/streetmix/')
 })
 

--- a/app.js
+++ b/app.js
@@ -46,6 +46,10 @@ app.all('*', function (req, res, next) {
   }
 })
 
+app.get('/help/about', function (req, res, next) {
+  res.redirect('https://www.opencollective.com/streetmix/')
+})
+
 app.get('/twitter-sign-in', controllers.twitter_sign_in.get)
 app.get(config.twitter.oauth_callback_uri, controllers.twitter_sign_in_callback.get)
 


### PR DESCRIPTION
In PR #569 I removed the implementation of the `/help/about` route in the front-end so that our "landing page" can be directed to https://opencollective.com/streetmix, which is a more updated version of our mission statement and team. This PR implements routing on the back-end to perform the redirect.