### PR TITLE
Replace standard with eslint configs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+assets/scripts/vendor/
+test/integration/smoke.spec.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,17 @@
 {
-  "extend": ["standard", "standard-react"],
-  "parser": "babel-eslint"
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true,
+    "mocha": true
+  },
+  "plugins": ["react"],
+  "extends": ["standard", "standard-react"]
 }

--- a/assets/scripts/dialogs/AboutDialog.jsx
+++ b/assets/scripts/dialogs/AboutDialog.jsx
@@ -20,50 +20,50 @@ export default class AboutDialog extends React.Component {
 
   render () {
     return (
-      <Dialog className='about-dialog'>
+      <Dialog className="about-dialog">
         <h1>{t('dialogs.about.heading', 'About Streetmix.')}</h1>
-        <div className='about-dialog-left'>
-          <div className='about-dialog-description'>
+        <div className="about-dialog-left">
+          <div className="about-dialog-description">
             {t('dialogs.about.description', 'Design, remix, and share your street. Add bike paths, widen sidewalks or traffic lanes, learn how all of this can impact your community.')}
           </div>
           <ul>
             <li>
-              <a href='http://blog.streetmix.net' target='_blank'>
+              <a href="http://blog.streetmix.net" target="_blank">
                 {t('menu.contact.blog', 'Visit Streetmix blog')}
               </a>
             </li>
             <li>
-              <a href='https://github.com/codeforamerica/streetmix/' target='_blank'>
+              <a href="https://github.com/codeforamerica/streetmix/" target="_blank">
                 {t('dialogs.about.view-source', 'View source code')}
               </a>
             </li>
           </ul>
         </div>
-        <div className='about-dialog-right'>
+        <div className="about-dialog-right">
           <p>
-            A side project by <a target='_blank' href='http://codeforamerica.org'>Code for America</a> 2013 fellows:
+            A side project by <a target="_blank" href="http://codeforamerica.org">Code for America</a> 2013 fellows:
           </p>
-          <ul className='about-dialog-team'>
+          <ul className="about-dialog-team">
             <li>
-              <a target='_blank' href='http://twitter.com/anselmbradford'><div className='avatar' data-user-id='anselmbradford'></div>Anselm Bradford</a> · media production
+              <a target="_blank" href="http://twitter.com/anselmbradford"><div className="avatar" data-user-id="anselmbradford" />Anselm Bradford</a> · media production
             </li>
             <li>
-              <a target='_blank' href='http://ahhrrr.com'><div className='avatar' data-user-id='ahhrrr'></div>Ezra Spier</a> · cat herder, proto-urbanist
+              <a target="_blank" href="http://ahhrrr.com"><div className="avatar" data-user-id="ahhrrr" />Ezra Spier</a> · cat herder, proto-urbanist
             </li>
             <li>
-              <a target='_blank' href='http://twitter.com/klizlewis'><div className='avatar' data-user-id='klizlewis'></div>Katie Lewis</a> · illustrator
+              <a target="_blank" href="http://twitter.com/klizlewis"><div className="avatar" data-user-id="klizlewis" />Katie Lewis</a> · illustrator
             </li>
             <li>
-              <a target='_blank' href='http://louhuang.com'><div className='avatar' data-user-id='saikofish'></div>Lou Huang</a> · project lead, research, outreach, transit fan
+              <a target="_blank" href="http://louhuang.com"><div className="avatar" data-user-id="saikofish" />Lou Huang</a> · project lead, research, outreach, transit fan
             </li>
             <li>
-              <a target='_blank' href='http://www.linkedin.com/pub/marc-hebert/1/2bb/66'><div className='avatar' data-user-id='anthromarc'></div>Marc Hébert</a> · UX researcher, design anthropologist
+              <a target="_blank" href="http://www.linkedin.com/pub/marc-hebert/1/2bb/66"><div className="avatar" data-user-id="anthromarc" />Marc Hébert</a> · UX researcher, design anthropologist
             </li>
             <li>
-              <a target='_blank' href='http://aresluna.org'><div className='avatar' data-user-id='mwichary'></div>Marcin Wichary</a> · UX, FE, PM, sharrow whisperer
+              <a target="_blank" href="http://aresluna.org"><div className="avatar" data-user-id="mwichary" />Marcin Wichary</a> · UX, FE, PM, sharrow whisperer
             </li>
             <li>
-              <a target='_blank' href='http://twitter.com/shaunak'><div className='avatar' data-user-id='shaunak'></div>Shaunak Kashyap</a> · rear end engineering
+              <a target="_blank" href="http://twitter.com/shaunak"><div className="avatar" data-user-id="shaunak" />Shaunak Kashyap</a> · rear end engineering
             </li>
           </ul>
           <footer>

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -39,13 +39,18 @@ export default class Dialog extends React.Component {
     }
 
     return (
-      <div className='dialog-box-container'>
-        <div className='dialog-box-shield' onClick={this.unmountDialog}></div>
+      <div className="dialog-box-container">
+        <div className="dialog-box-shield" onClick={this.unmountDialog} />
         <div className={className}>
-          <button className='close' onClick={this.unmountDialog}>×</button>
+          <button className="close" onClick={this.unmountDialog}>×</button>
           {this.props.children}
         </div>
       </div>
     )
   }
+}
+
+Dialog.propTypes = {
+  className: React.PropTypes.string,
+  children: React.PropTypes.node
 }

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -126,55 +126,55 @@ export default class SaveAsImageDialog extends React.Component {
 
   render () {
     return (
-      <Dialog className='save-as-image-dialog'>
+      <Dialog className="save-as-image-dialog">
         <h1>{t('dialogs.save.heading', 'Save as image')}</h1>
         <p>
           <input
-            type='checkbox'
+            type="checkbox"
             onChange={this.onChangeOptionSegmentNames}
             checked={this.state.optionSegmentNames}
-            id='save-as-image-segment-names'
+            id="save-as-image-segment-names"
           />
-          <label htmlFor='save-as-image-segment-names'>
+          <label htmlFor="save-as-image-segment-names">
             {t('dialogs.save.option-labels', 'Segment names and widths')}
           </label>
 
           <input
-            type='checkbox'
+            type="checkbox"
             onChange={this.onChangeOptionStreetName}
             checked={this.state.optionStreetName}
-            id='save-as-image-street-name'
+            id="save-as-image-street-name"
           />
-          <label htmlFor='save-as-image-street-name'>
+          <label htmlFor="save-as-image-street-name">
             {t('dialogs.save.option-name', 'Street name')}
           </label>
 
           <input
-            type='checkbox'
+            type="checkbox"
             onChange={this.onChangeOptionTransparentSky}
             checked={this.state.optionTransparentSky}
-            id='save-as-image-transparent-sky'
+            id="save-as-image-transparent-sky"
           />
-          <label htmlFor='save-as-image-transparent-sky'>
+          <label htmlFor="save-as-image-transparent-sky">
             {t('dialogs.save.option-sky', 'Transparent sky')}
           </label>
         </p>
         {(() => {
           if (this.state.errorMessage) {
             return (
-              <div id='save-as-image-preview'>
-                <div className='save-as-image-preview-loading'>
+              <div id="save-as-image-preview">
+                <div className="save-as-image-preview-loading">
                   {this.state.errorMessage}
                 </div>
               </div>
             )
           } else {
             return (
-              <div id='save-as-image-preview'>
-                <div className='save-as-image-preview-loading' style={{display: this.state.isLoading ? 'block' : 'none'}}>
+              <div id="save-as-image-preview">
+                <div className="save-as-image-preview-loading" style={{display: this.state.isLoading ? 'block' : 'none'}}>
                   {t('dialogs.save.loading', 'Loading…')}
                 </div>
-                <div className='save-as-image-preview-image' style={{display: this.state.isLoading ? 'none' : 'block'}}>
+                <div className="save-as-image-preview-image" style={{display: this.state.isLoading ? 'none' : 'block'}}>
                   <img
                     src={this.state.download.dataUrl}
                     onLoad={this.onPreviewLoaded}
@@ -188,7 +188,7 @@ export default class SaveAsImageDialog extends React.Component {
         })()}
         <p>
           <a
-            className='button-like'
+            className="button-like"
             onClick={this.onClickDownloadImage}
             // Sets the anchor's `download` attribute so that it saves a meaningful filename
             // Note that this property is not supported in Safari/iOS

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "posttest": "mongo admin --eval 'db.shutdownServer()'",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-css": "sass-lint --config .sass-lint.yml  --verbose",
-    "lint-js": "standard --verbose | snazzy",
+    "lint-js": "eslint \"**/*.js\" \"**/*.jsx\"",
     "translationsDownload": "node bin/download_translations.js"
   },
   "dependencies": {
@@ -83,6 +83,11 @@
   },
   "devDependencies": {
     "eslint": "2.13.1",
+    "eslint-config-standard": "5.3.5",
+    "eslint-config-standard-react": "3.0.0",
+    "eslint-plugin-promise": "2.0.1",
+    "eslint-plugin-react": "6.0.0",
+    "eslint-plugin-standard": "2.0.0",
     "grunt": "1.0.1",
     "grunt-env": "0.4.4",
     "grunt-express": "1.4.1",
@@ -91,19 +96,10 @@
     "load-grunt-tasks": "3.5.0",
     "proxyquire": "1.7.9",
     "sass-lint": "1.8.2",
-    "snazzy": "4.0.0",
-    "standard": "7.1.2",
-    "standard-react": "2.1.0",
     "supertest": "1.2.0",
     "tap-spec": "4.1.1",
     "tape": "4.6.0",
     "tape-catch": "1.0.6"
-  },
-  "standard": {
-    "ignore": [
-      "assets/scripts/vendor/",
-      "test/integration/smoke.spec.js"
-    ]
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Following up from the conversation in PR #569, this removes the `standard` and `standard-react` convenience packages for linting and replaces it with a fully `eslint`-based linting configuration, which already existed to serve CodeClimate. This installs the configuration packages that `standard` and `standard-react` will include, but gives us the flexibility to modify `eslintrc.json` when we need to.

The previous method didn't actually work for linting React, so this PR also includes updates to the recently merged `.jsx` files to meet the rules in `standard-react`.