### PR TITLE
Small tweak in Dialog.jsx to remove findDOMNode()

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,5 +13,8 @@
     "mocha": true
   },
   "plugins": ["react"],
-  "extends": ["standard", "standard-react"]
+  "extends": ["standard", "standard-react"],
+  "rules": {
+    "react/jsx-no-bind": [2, { "ignoreRefs": true }]
+  }
 }

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -29,7 +29,7 @@ export default class Dialog extends React.Component {
   }
 
   unmountDialog () {
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(this).parentNode)
+    ReactDOM.unmountComponentAtNode(this.dialogEl.parentNode)
   }
 
   render () {
@@ -39,7 +39,7 @@ export default class Dialog extends React.Component {
     }
 
     return (
-      <div className='dialog-box-container'>
+      <div className='dialog-box-container' ref={(ref) => { this.dialogEl = ref }}>
         <div className='dialog-box-shield' onClick={this.unmountDialog} />
         <div className={className}>
           <button className='close' onClick={this.unmountDialog}>×</button>


### PR DESCRIPTION
Small tweak; not much going on. Apparently, `findDOMNode` will eventually be deprecated (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md). Additionally, from React docs: "findDOMNode() is an escape hatch used to access the underlying DOM node. In most cases, use of this escape hatch is discouraged because it pierces the component abstraction." (https://facebook.github.io/react/docs/top-level-api.html#reactdom.finddomnode)

Tests appear to be failing because Sauce Labs shut off its free tier a month ago.
