### PR TITLE
Add an .editorconfig for text editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig (http://EditorConfig.org)
+
+# top-most EditorConfig file
+root = true
+
+[*.{js,jsx,json,jade,css,yml}]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
@magul - I am not sure if you use editorconfig, but this is a way for text editors to immediately adopt the correct tab spacing (amongst other settings) when the project is opened. This is starting to become useful for me since I have projects at my day job that use 4-space tabs by default.