### PR TITLE
Removing css lint warning.

### DIFF
--- a/assets/css/_menu-bar.scss
+++ b/assets/css/_menu-bar.scss
@@ -122,7 +122,6 @@ $top-menu-active-text: darken($ui-colour, 40%);
   margin-left: 0.25em;
 
   h1 {
-    display: inline-block;
     padding: 0;
     margin: 0;
     margin-left: 0.25em;


### PR DESCRIPTION
When adding the Streetmix logo, a duplicate display line was added. 