### PR TITLE
Local Testing Chrome driver

### DIFF
--- a/test/integration/local.conf.js
+++ b/test/integration/local.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   chromeOnly: true,
-  chromeDriver: '../../node_modules/protractor/selenium/chromedriver',
+  // chromeDriver: '../../node_modules/protractor/selenium/chromedriver',
   capabilities: {
     'browserName': 'chrome'
   },

--- a/test/integration/local.conf.js
+++ b/test/integration/local.conf.js
@@ -1,6 +1,5 @@
 exports.config = {
   chromeOnly: true,
-  // chromeDriver: '../../node_modules/protractor/selenium/chromedriver',
   capabilities: {
     'browserName': 'chrome'
   },


### PR DESCRIPTION
I wasn't able to run local tests without commenting out this line. the chrome driver is actually at node_modules/protractor/selenium/chromedriver_2.21

@louh can you test this locally and see that it works for you too?