### PR TITLE
Replace $.animate() with shifty.js.

### DIFF
--- a/assets/scripts/gallery/scroll.js
+++ b/assets/scripts/gallery/scroll.js
@@ -2,8 +2,7 @@
  * Adds scroll buttons to gallery and palette.
  *
  */
-import $ from 'jquery'
-import { getElAbsolutePos } from '../util/helpers'
+import { animate, getElAbsolutePos } from '../util/helpers'
 
 export function attachGalleryScrollEventListeners () {
   window.addEventListener('stmx:everything_loaded', function () {
@@ -54,7 +53,7 @@ function onScrollButtonLeft (event) {
   const position = el.scrollLeft - (el.offsetWidth - 150) // TODO: document magic number
   const duration = 300
 
-  $(el).animate({ scrollLeft: position }, duration)
+  animate(el, { scrollLeft: position }, duration)
 }
 
 function onScrollButtonRight (event) {
@@ -62,7 +61,7 @@ function onScrollButtonRight (event) {
   const position = el.scrollLeft + (el.offsetWidth - 150) // TODO: document magic number
   const duration = 300
 
-  $(el).animate({ scrollLeft: position }, duration)
+  animate(el, { scrollLeft: position }, duration)
 }
 
 function onScrollButtonScroll (event) {

--- a/assets/scripts/streets/scroll.js
+++ b/assets/scripts/streets/scroll.js
@@ -2,12 +2,12 @@
  * Handles scrolling the street.
  *
  */
-import $ from 'jquery'
 import { registerKeypress } from '../app/keypress'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { system } from '../preinit/system_capabilities'
 import { getStreet } from './data_model'
 import { MAX_CUSTOM_STREET_WIDTH } from './width'
+import { animate } from '../util/helpers'
 
 export function attachStreetScrollEventListeners () {
   window.addEventListener('stmx:everything_loaded', function () {
@@ -33,8 +33,6 @@ function scrollStreet (left, far = false) {
   const el = document.querySelector('#street-section-outer')
   let newScrollLeft
 
-  $(el).stop(true, true)
-
   if (left) {
     if (far) {
       newScrollLeft = 0
@@ -49,8 +47,7 @@ function scrollStreet (left, far = false) {
     }
   }
 
-  // TODO const
-  $(el).animate({ scrollLeft: newScrollLeft }, 300)
+  animate(el, { scrollLeft: newScrollLeft }, 300)
 }
 
 function updateStreetScrollIndicators () {

--- a/assets/scripts/ui/Scrollable.jsx
+++ b/assets/scripts/ui/Scrollable.jsx
@@ -2,7 +2,7 @@
  * Adds scroll buttons to UI elements.
  */
 import React from 'react'
-import $ from 'jquery'
+import { animate } from '../util/helpers'
 
 export default class Scrollable extends React.PureComponent {
   constructor (props) {
@@ -32,14 +32,14 @@ export default class Scrollable extends React.PureComponent {
     const el = this.scroller
     const position = el.scrollLeft - (el.offsetWidth - 150) // TODO: document magic number
 
-    $(el).animate({ scrollLeft: position }, this.duration)
+    animate(el, { scrollLeft: position }, this.duration)
   }
 
   onClickRight (event) {
     const el = this.scroller
     const position = el.scrollLeft + (el.offsetWidth - 150) // TODO: document magic number
 
-    $(el).animate({ scrollLeft: position }, this.duration)
+    animate(el, { scrollLeft: position }, this.duration)
   }
 
   onScrollContainer (event) {

--- a/assets/scripts/util/helpers.js
+++ b/assets/scripts/util/helpers.js
@@ -1,3 +1,5 @@
+import Tweenable from 'shifty'
+
 /**
  * Gets the absolute position in pixels of a given element,
  * taking into account its CSS transformed position.
@@ -34,4 +36,31 @@ export function normalizeSlug (slug) {
   slug = slug.replace(/^[-]+|[-]+$/g, '')
 
   return slug
+}
+
+/**
+ * Tweens the given numeric properties on an element over time.
+ *
+ * @param {Element} el
+ * @param {Object<string, number>} props
+ * @param {number} duration
+ */
+export function animate (el, props, duration) {
+  const initialProps = {}
+
+  Object.keys(props).forEach(function (prop) {
+    initialProps[prop] = el[prop] || 0
+  })
+
+  if (el.tweenable) {
+    el.tweenable.stop()
+  }
+
+  el.tweenable = new Tweenable()
+  el.tweenable.tween({
+    from: initialProps,
+    to: props,
+    duration: duration,
+    step: (state) => Object.assign(el, state)
+  })
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "request": "2.72.0",
     "requireindex": "1.1.0",
     "sendgrid": "2.0.0",
+    "shifty": "1.5.2",
     "sprintf": "0.1.5",
     "streetmix-icons": "git://github.com/streetmix/icons.git#v0.4.1",
     "streetmix-illustrations": "git://github.com/streetmix/illustrations.git",


### PR DESCRIPTION
Fixes #537.

I haven't been able to test gallery/scroll.js yet – how can I obtain a Twitter consumer key/secret from the streetmix twitter account, if I'm understanding CONTRIBUTING.md right?

This would be one prereq for removing jQuery, which weighs about 74kb gzipped. This PR uses [shifty](https://github.com/jeremyckahn/shifty) instead, which is 4kb gzipped. I also looked at the more popular [tween.js](https://github.com/tweenjs/tween.js/), but it expects users to implement an external requestAnimationFrame loop, which in turn needs to be polyfilled, etc.

Or this could be done without any dependencies, but with a bit more code. Aside, [I've filed an issue](https://github.com/jeremyckahn/shifty/issues/88) to verify browser compatibility of shifty.