### PR TITLE
Group certain React components together into a single parent component

### DIFF
--- a/app/views/main.jade
+++ b/app/views/main.jade
@@ -11,8 +11,9 @@ block main
 
   #main-screen
 
-    //- Mount point for React-based menus
-    #menus
+    //- Mount point for React
+    #react-app
+    #dialogs-react
 
     .info-bubble
 
@@ -24,13 +25,6 @@ block main
         | Streetmix is having trouble connecting to the Internet.
         button#no-connection-try-again.
           Try again
-
-    #street-header
-
-    #dialogs-react
-
-    //- Mount point for React WelcomePanel
-    #welcome
 
     section#street-section-outer
       #gallery-shield
@@ -51,9 +45,6 @@ block main
       .front-clouds
     #street-scroll-indicator-left
     #street-scroll-indicator-right
-
-    //- Mount point for React
-    #palette
 
   #print
     div

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { app } from '../preinit/app_settings'
+import MenusContainer from '../menus/MenusContainer'
+import StreetNameCanvas from '../streets/StreetNameCanvas'
+import WelcomePanel from './WelcomePanel'
+import Palette from './Palette'
+
+export default class App extends React.PureComponent {
+  render () {
+    return (
+      <div>
+        <MenusContainer />
+        <StreetNameCanvas allowEditing={!app.readOnly} />
+        <WelcomePanel />
+        <Palette />
+      </div>
+    )
+  }
+}

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -20,12 +20,8 @@ import './vendor/polyfills/customevent' // customEvent in IE
 import { initialize } from './app/initialization'
 import { startListening } from './app/keypress'
 import { system } from './preinit/system_capabilities'
-import { app } from './preinit/app_settings'
-import MenusContainer from './menus/MenusContainer'
-import Palette from './app/Palette'
-import StreetNameCanvas from './streets/StreetNameCanvas'
+import App from './app/App'
 import DebugInfo from './app/DebugInfo'
-import WelcomePanel from './app/WelcomePanel'
 
 // Error tracking
 // Load this before all other modules. Only load when run in production.
@@ -51,11 +47,8 @@ function setScaleForPhone () {
 setScaleForPhone()
 
 // Temp: mount React components
-ReactDOM.render(<MenusContainer />, document.getElementById('menus'))
-ReactDOM.render(<Palette />, document.getElementById('palette'))
-ReactDOM.render(<StreetNameCanvas allowEditing={!app.readOnly} />, document.getElementById('street-header'))
+ReactDOM.render(<App />, document.getElementById('react-app'))
 ReactDOM.render(<DebugInfo />, document.getElementById('debug'))
-ReactDOM.render(<WelcomePanel />, document.getElementById('welcome'))
 
 // Start listening for keypresses
 startListening()


### PR DESCRIPTION
I've been poking around at react-intl this past week (it will solve the problem of having interactive React components within strings! but there are other complexities to work through to adopt it) -- anyway, it depends on wrapping the application's root component with a provider component, which we don't really have right now because are porting individual components and mounting each of them separately. Since Redux also uses this pattern, and we have a number of these components now, I thought some of them could be bundled together under a single component so that it's more possible to wrap a bunch of them at once with these provider components, and not each of them individually.

Two mount point nodes were not included: `#debug-info`, which exists higher up outside of `#main-screen` right now - eventually we'd grow `<App />` to the point where it can encompass all these things. The other is `#dialogs-react`, since dialogs are just mounted when they're activated. I haven't quite figured out the best way to address this (probably a parent `<DialogContainer />` component that renders individual Dialogs based on some prop?)

I made this change from my `welcome` branch because that component can also be bundled here, but I can also re-do this PR off of `master` if we want to start there.

Thoughts? @ryross 