### PR TITLE
Added foot/inch combination conversions

### DIFF
--- a/assets/scripts/util/width_units.js
+++ b/assets/scripts/util/width_units.js
@@ -42,7 +42,7 @@ export function processWidthInput (widthInput) {
 
   let width
 
-  // The conditional makes sure we only parse when the input includes ' as any character except the last
+  // The conditional makes sure we only split and parse separately when the input includes ' as any character except the last
   if (widthInput.indexOf("'") !== -1 && widthInput.length > widthInput.indexOf("'") + 1) {
     widthInput = widthInput.split("'")
     width = widthInput.reduce(function (prev, cur) {
@@ -176,7 +176,7 @@ function stringifyMetricWidth (width) {
  * value multiplied by the appropriate multiplier.
  *
  * @param {String} widthInput to convert to number
- * @returns {Number} formated width as number
+ * @returns {Number} formatted width as number
  */
 function parseStringForUnits (widthInput) {
   if (widthInput.indexOf('-') !== -1) {

--- a/assets/scripts/util/width_units.js
+++ b/assets/scripts/util/width_units.js
@@ -40,26 +40,20 @@ export function processWidthInput (widthInput) {
     }
   }
 
-  let width = parseFloat(widthInput)
+  let width
 
-  if (width) {
-    // Default multiplier, is true if units are imperial
-    let multiplier = 1
-
-    // TODO remove call to getStreet. Pass in units instead
-    // Default unit
-    if (getStreet().units === SETTINGS_UNITS_METRIC) {
-      multiplier = 1 / IMPERIAL_METRIC_MULTIPLIER
-    }
-
-    for (let i in WIDTH_INPUT_CONVERSION) {
-      if (widthInput.match(new RegExp('[\\d\\.]' + WIDTH_INPUT_CONVERSION[i].text + '$'))) {
-        multiplier = WIDTH_INPUT_CONVERSION[i].multiplier
-        break
+  // The conditional makes sure we only parse when the input includes ' as any character except the last
+  if (widthInput.indexOf("'") !== -1 && widthInput.length > widthInput.indexOf("'") + 1) {
+    widthInput = widthInput.split("'")
+    width = widthInput.reduce(function (prev, cur) {
+      if (cur.indexOf('"') === -1) { // Assuming anything coming after feet is going to be inches
+        cur += '"'
       }
-    }
 
-    width *= multiplier
+      return parseStringForUnits(prev.toString()) + parseStringForUnits(cur.toString())
+    })
+  } else {
+    width = parseStringForUnits(widthInput)
   }
 
   return width
@@ -175,4 +169,41 @@ function stringifyMetricWidth (width) {
   }
 
   return widthText
+}
+
+/**
+ * Given a width in any unit (including no unit), parses for units and returns
+ * value multiplied by the appropriate multiplier.
+ *
+ * @param {String} widthInput to convert to number
+ * @returns {Number} formated width as number
+ */
+function parseStringForUnits (widthInput) {
+  if (widthInput.indexOf('-') !== -1) {
+    widthInput = widthInput.replace(/-/g, '') // Dashes would mean negative in the parseFloat
+  }
+
+  let width = parseFloat(widthInput)
+
+  if (width) {
+    // Default multiplier, is true if units are imperial
+    let multiplier = 1
+
+    // TODO remove call to getStreet. Pass in units instead
+    // Default unit
+    if (getStreet().units === SETTINGS_UNITS_METRIC) { // Checks for a unitless input when metric
+      multiplier = 1 / IMPERIAL_METRIC_MULTIPLIER
+    }
+
+    for (let i in WIDTH_INPUT_CONVERSION) {
+      if (widthInput.match(new RegExp('[\\d\\.]' + WIDTH_INPUT_CONVERSION[i].text + '$'))) {
+        multiplier = WIDTH_INPUT_CONVERSION[i].multiplier
+        break
+      }
+    }
+    width *= multiplier
+    return width
+  } else {
+    return 0 // Allows for leading zeros, like 0'7"
+  }
 }

--- a/assets/scripts/util/width_units.js
+++ b/assets/scripts/util/width_units.js
@@ -45,6 +45,7 @@ export function processWidthInput (widthInput) {
   // The conditional makes sure we only split and parse separately when the input includes ' as any character except the last
   if (widthInput.indexOf("'") !== -1 && widthInput.length > widthInput.indexOf("'") + 1) {
     widthInput = widthInput.split("'")
+    widthInput[0] += "'" // Add the ' to the first value so the parser knows to convert in feet, not in unitless, when in metric
     width = widthInput.reduce(function (prev, cur) {
       if (cur.indexOf('"') === -1) { // Assuming anything coming after feet is going to be inches
         cur += '"'


### PR DESCRIPTION
#390 Updated width_units.js to allow for foot/inch input.  Regular inputs (7, 7', 7", 7m) still work.  Included formats include the following:

-  7'-9"
- 7'9"
- 7'9
- Leading zero eg 0'6" (in case anyone wanted an odd leading zero for their inch input)

Main difference was making a separate function for parsing the input for units, and then either parsing all sections of the input (separated by a single apostrophe, indicating a foot/inch combination input) and combining with reduce or just parsing the input (for regular integers and single units).

Tested with local Mocha tests on many inputs (wanted to check before adding Mocha to full project), and checked with eslint and npm test as well.  If anyone has any advice or recommendation for incorporating a new test (featuring es6 for the imports of width_units and its dependencies) into the existing test structure, please let me know, and feel free to let me know if you would like to see any changes!