### PR TITLE
Add data-i18n attribute to translate the "Empty space" label

### DIFF
--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -372,7 +372,8 @@ function fillEmptySegment (el) {
   let innerEl
   innerEl = document.createElement('span')
   innerEl.classList.add('name')
-  innerEl.innerHTML = msg('SEGMENT_NAME_EMPTY')
+  innerEl.textContent = msg('SEGMENT_NAME_EMPTY')
+  innerEl.setAttribute('data-i18n', 'section.empty')
   el.appendChild(innerEl)
 
   innerEl = document.createElement('span')


### PR DESCRIPTION
"Empty space" label did not have an `data-i18n` attribute to pick up translations. This is a relatively simple fix to make this work. cc @treyhahn

![image](https://cloud.githubusercontent.com/assets/2553268/19671752/069c344e-9a3f-11e6-8b68-6542fdd206d2.png)
