### PR TITLE
Fix error overlay

### DIFF
--- a/app/views/ui/blocking.jade
+++ b/app/views/ui/blocking.jade
@@ -3,11 +3,11 @@
   progress(id='loading-progress', value=0, max=1)
 
 #error
+  .rear-clouds
+  .front-clouds
   .error-content
     h1#error-title
     div#error-description.error-description
-    .rear-clouds
-    .front-clouds
 
 #blocking-shield
   .message

--- a/assets/css/_chrome.scss
+++ b/assets/css/_chrome.scss
@@ -31,6 +31,7 @@ body.phone #loading {
   }
 
   .error-content {
+    position: relative;
     text-align: center;
     line-height: 1.6;
 
@@ -245,4 +246,3 @@ body.controls-fade-out .segment:not(.unmovable).hover .hover-bk {
     margin-left: 0.25em;
   }
 }
-

--- a/assets/css/_gallery.scss
+++ b/assets/css/_gallery.scss
@@ -18,7 +18,7 @@ body:not(.safari).gallery-visible #street-section-sky {
   right: $left-right-inset + 20px;
   top: 0;
   height: $gallery-height;
-  z-index: $z-03-gallery;
+  z-index: $z-09-gallery;
 
   border-bottom: 3px solid darken($ui-colour, 30%);
 
@@ -248,7 +248,7 @@ body:not(.safari).gallery-visible #street-section-sky {
     z-index: $z-03-gallery-message;
     background: white;
 
-    padding-top: 85px;
+    padding-top: 80px;
 
     display: none;
 

--- a/assets/css/_sky.scss
+++ b/assets/css/_sky.scss
@@ -21,15 +21,15 @@
 
 .rear-clouds {
   height: 120px;
-  bottom: 735px;
+  bottom: 480px;
   background-image: url('/images/sky-rear.png');
   background-size: 250px 120px;
 }
 
 .front-clouds {
   height: 280px;
-  bottom: 735px - 330px;
-  border-bottom: 50px solid rgb(165, 196, 209);
+  bottom: 0;
+  border-bottom: 200px solid rgb(165, 196, 209);
   background-image: url('/images/sky-front.png');
   background-size: 250px 280px;
   opacity: 0.5;

--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -67,7 +67,6 @@ $z-02-segment-focused:      $z-index-02;
 $z-02-palette:              $z-index-02;
 $z-02-menu-bar:             $z-index-02;
 $z-03-street-name:          $z-index-03;
-$z-03-gallery:              $z-index-03;
 $z-03-gallery-message:      $z-index-03;
 $z-04-menu:                 $z-index-04;
 $z-04-palette-scroll:       $z-index-04; // Match command menu
@@ -81,6 +80,7 @@ $z-07-trashcan:             $z-index-07;
 $z-07-segment-guide:        $z-index-07;
 $z-08-dialog-box-shield:    $z-index-08;
 $z-08-gallery-shield:       $z-index-08;
+$z-09-gallery:              $z-index-09;
 $z-09-dialog-box:           $z-index-09;
 $z-09-debug:                $z-index-09;
 

--- a/assets/scripts/app/window_resize.js
+++ b/assets/scripts/app/window_resize.js
@@ -52,7 +52,7 @@ export function onResize () {
   document.querySelector('#street-section-inner').style.top = streetSectionTop + 'px'
 
   document.querySelector('#street-section-sky').style.top =
-    (streetSectionTop * 0.8) + 'px'
+    (streetSectionTop * 0.8 - 255) + 'px'
 
   document.querySelector('#street-scroll-indicator-left').style.top =
     (streetSectionTop + streetSectionHeight) + 'px'


### PR DESCRIPTION
Happy new year!

This is a quick fix for some regressions (my fault from at least year ago) that have been bothering me.

1. Error screens had the clouds overlay the error message, so in some cases the buttons aren't even clickable. This is fixed.

<img width="1200" alt="screenshot 2017-01-10 16 38 44" src="https://cloud.githubusercontent.com/assets/2553268/21830685/4a75537a-d753-11e6-944e-d927eddf2b6b.png">

2. If you delete a street from the gallery and it's the street you're currently looking at, the gallery disappears (it's obscured by the "No street selected" message), so you can't get back to another street. This is fixed.

![jan-10-2017 16-39-22](https://cloud.githubusercontent.com/assets/2553268/21830707/6c63e352-d753-11e6-9723-032042d6757a.gif)


